### PR TITLE
Explicity load linux shared libraries with dlopen

### DIFF
--- a/NativeLibraryManager/LibraryFile.cs
+++ b/NativeLibraryManager/LibraryFile.cs
@@ -79,6 +79,22 @@ namespace NativeLibraryManager
 			File.WriteAllBytes(path, bytes);
 		}
 
+		private const int RTLD_LAZY = 0x00001; //Only resolve symbols as needed
+		private const int RTLD_GLOBAL = 0x00100; //Make symbols available to libraries loaded later
+		[DllImport("dl")]
+		private static extern IntPtr dlopen (string file, int mode);
+		
+		internal void LoadLinuxLibrary(string path)
+		{
+			Log.Info($"Linux dlopen of {path}");
+			var result = dlopen(path, RTLD_LAZY | RTLD_GLOBAL);
+			if (result.Equals(null) )
+			{
+				Log.Info($"Linux dlopen failed to load {path}");
+			}
+		}
+
+
 		internal void LoadWindowsLibrary(string path)
 		{
 			Log.Info($"Directly loading {path}...");

--- a/NativeLibraryManager/LibraryItem.cs
+++ b/NativeLibraryManager/LibraryItem.cs
@@ -50,7 +50,12 @@ namespace NativeLibraryManager
                 if (Platform == Platform.Windows && loadLibrary)
                 {
                     Files[i].LoadWindowsLibrary(file);
-                }  
+                }
+
+                if (Platform == Platform.Linux && loadLibrary)
+                {
+                    Files[i].LoadLinuxLibrary(file);
+                }
             }
         }
     }

--- a/NativeLibraryManager/NativeLibraryManager.csproj
+++ b/NativeLibraryManager/NativeLibraryManager.csproj
@@ -5,7 +5,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <AssemblyVersion>1.0.1.0</AssemblyVersion>
     <FileVersion>1.0.1.0</FileVersion>
-    <Version>1.0.1</Version>
+    <Version>1.0.17</Version>
     <Authors>Oleg Tarasov</Authors>
     <Description>A .NET Standard 2.0 library to manage native dependencies stored as binary resources.</Description>
     <PackageProjectUrl>https://github.com/olegtarasov/NativeLibraryManager</PackageProjectUrl>


### PR DESCRIPTION
NativeLibraryManager was able to load all of my windows shared libraries, but I was not able to load dependency trees of linux shared libraries.  This patch makes the linux library loading more robust using dlopen.

Suppose you have a package A -- libA.so depends on libB.so and libC.so, and B depends on libD.so.  This modification allows that shared library dependency tree to load under linux.  There is a caveat that should be mentioned on the tutorial pages though.  The libraries with dependencies must occur last in the libManager file list -- order is important.  Use ldd to see the dependencies so they can be put in the right order.

Example.
        var accessor = new ResourceAccessor(Assembly.GetExecutingAssembly());
        var libManager = new LibraryManager(
          Assembly.GetExecutingAssembly(),
          new LibraryItem(Platform.Windows, Bitness.x64,
            new LibraryFile("A.dll", accessor.Binary("A.dll")),
            new LibraryFile("AMath.dll", accessor.Binary("AMath.dll")),
            new LibraryFile("B.dll", accessor.Binary("B.dll"))),
          new LibraryItem(Platform.Linux, Bitness.x64,
            new LibraryFile("libD.so", accessor.Binary("libD.so")),
            new LibraryFile("libC.so", accessor.Binary("libC.so")),
            new LibraryFile("libB.so", accessor.Binary("libB.so")),
            new LibraryFile("libAMath.so", accessor.Binary("libAMath.so")),
            new LibraryFile("libA.so", accessor.Binary("libA.so"))));
        libManager.LoadNativeLibrary();


The Embedded resource tags in the csproj needs to have all those libraries.
