### PR TITLE
Multiple log providers  and  .Net Frameworks 4x  are  supported.

### DIFF
--- a/NativeLibraryManager/LibraryFile.cs
+++ b/NativeLibraryManager/LibraryFile.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Microsoft.Extensions.Logging;
 
 namespace NativeLibraryManager
 {

--- a/NativeLibraryManager/LibraryItem.cs
+++ b/NativeLibraryManager/LibraryItem.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Microsoft.Extensions.Logging;
 
 namespace NativeLibraryManager
 {

--- a/NativeLibraryManager/LibraryItemInternal.cs
+++ b/NativeLibraryManager/LibraryItemInternal.cs
@@ -2,15 +2,14 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
-using Microsoft.Extensions.Logging;
 
 namespace NativeLibraryManager
 {
     internal class LibraryItemInternal : LibraryItem
     {
-        private readonly ILogger<LibraryItem> _logger;
+        private readonly (Action<string> LogInformation, Action<string> LogWarning)? _logger;
 
-        internal LibraryItemInternal(LibraryItem item, ILogger<LibraryItem> logger = null) 
+        internal LibraryItemInternal(LibraryItem item,  (Action<string> LogInformation, Action<string> LogWarning)?  logger ) 
             : base(item.Platform, item.Bitness, item.Files)
         {
             _logger = logger;

--- a/NativeLibraryManager/NativeLibraryManager.csproj
+++ b/NativeLibraryManager/NativeLibraryManager.csproj
@@ -12,8 +12,4 @@
     <DocumentationFile>bin\Release\NativeLibraryManager.xml</DocumentationFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
-  </ItemGroup>
-
 </Project>

--- a/NativeLibraryManager/NativeLibraryManager.csproj
+++ b/NativeLibraryManager/NativeLibraryManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45;net40</TargetFrameworks>
     <Authors>Oleg Tarasov</Authors>
     <Description>A .NET Standard 2.0 library to manage native dependencies stored as binary resources.</Description>
     <PackageProjectUrl>https://github.com/olegtarasov/NativeLibraryManager</PackageProjectUrl>
@@ -11,5 +11,14 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DocumentationFile>bin\Release\NativeLibraryManager.xml</DocumentationFile>
   </PropertyGroup>
+
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net45'">
+		<PackageReference Include="System.ValueTuple">
+			<Version>4.5.0</Version>
+		</PackageReference>
+	</ItemGroup>
+
+ 
 
 </Project>

--- a/TestProcess/Program.cs
+++ b/TestProcess/Program.cs
@@ -56,13 +56,17 @@ namespace TestProcess
                 _logger.LogWarning(e, $"Failed to cleanup libraries before running a test: {e.Message}");
             }
         }
-
-        [Verb]
+        (Action<string> LogInformation, Action<string> LogWarning)  LogCreate(Type  type)
+        {
+            var logger = _factory.CreateLogger(type);
+            return (info => logger.LogInformation(info), war => logger.LogWarning(war));
+        }
+       [Verb]
         public int CanLoadLibraryFromCurrentDirAndCallFunction()
         {
             var accessor = new ResourceAccessor(Assembly.GetExecutingAssembly());
-            var libManager = new LibraryManager(
-                _factory,
+
+            var libManager = new LibraryManager(LogCreate,
                 new LibraryItem(Platform.MacOs, Bitness.x64,
                     new LibraryFile("libTestLib.dylib", accessor.Binary("libTestLib.dylib"))),
                 new LibraryItem(Platform.Windows, Bitness.x64, 
@@ -88,7 +92,7 @@ namespace TestProcess
             var accessor = new ResourceAccessor(Assembly.GetExecutingAssembly());
             var libManager = new LibraryManager(
                 tempDir,
-                _factory,
+                LogCreate,
                 new LibraryItem(Platform.MacOs, Bitness.x64,
                     new LibraryFile("libTestLib.dylib", accessor.Binary("libTestLib.dylib"))),
                 new LibraryItem(Platform.Windows, Bitness.x64,


### PR DESCRIPTION
Replace   ILoggerFactory 
with  this code  
```
   (Action<string> LogInformation, Action<string> LogWarning)  LogCreate(Type  type)
        {
            var logger = _factory.CreateLogger(type);
            return (info => logger.LogInformation(info), war => logger.LogWarning(war));
        }
```